### PR TITLE
Fix: 배포한 SpringBoot 컨테이너가 비정상적으로 종료되는 상황 해결

### DIFF
--- a/src/main/java/com/idle/fmd/global/config/etc/DataSourceConfig.java
+++ b/src/main/java/com/idle/fmd/global/config/etc/DataSourceConfig.java
@@ -10,13 +10,13 @@ import javax.sql.DataSource;
 @Configuration
 public class DataSourceConfig {
 
-    @Value("${SPRING_DATASOURCE_URL}")
+    @Value("${spring.batch.jdbc.url}")
     private String dataSourceUrl;
 
-    @Value("${SPRING_DATASOURCE_USERNAME}")
+    @Value("${spring.batch.jdbc.username}")
     private String dataSourceUsername;
 
-    @Value(("${SPRING_DATASOURCE_PASSWORD}"))
+    @Value("${spring.batch.jdbc.password}")
     private String dataSourcePassword;
     @Bean
     public DataSource dataSource() {


### PR DESCRIPTION
원인: DataSourceConfig 클래스에서 @Value로 값을 yaml에서 가져오는 것이 아닌 IDEA의 환경변수에서가져오는 것을 수정
#87 