### PR TITLE
Fix: 개발 서버(devleop)에서 Oatuh 로그인 동작 오류 해결

### DIFF
--- a/src/main/java/com/idle/fmd/global/auth/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/idle/fmd/global/auth/oauth2/OAuth2SuccessHandler.java
@@ -51,7 +51,8 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                     .password(providerId)
                     .build());
         }
-
+        // 도메인 주소값 추출
+        String domainUrl = request.getRequestURL().toString().replace(request.getRequestURI(), "");
         try{
             // 데이터베이스에서 사용자 회수
             UserDetails details
@@ -60,15 +61,14 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             String jwt = tokenUtils.generateToken(details);
 
             // 목적지 URL 설정
-            // 우리 서비스의 Frontend 구성에 따라 유연하게 대처해야 한다.
-            String targetUrl = String.format("http://localhost:8080/users/oauth?token=%s", jwt);
+            String targetUrl = String.format("%s/users/oauth?token=%s", domainUrl, jwt);
             // 실제 Redirect 응답 생성
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
 
         }catch (Exception e){
             log.error(e.getMessage());
             // oauth 인증 실패 시 oauth-fail URL 로 리다이렉트
-            String targetUrl = String.format("http://localhost:8080/users/oauth-fail");
+            String targetUrl = String.format("%s/users/oauth-fail", domainUrl);
             getRedirectStrategy().sendRedirect(request, response, targetUrl);
         }
     }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -2,7 +2,7 @@ spring:
   profiles:
     active: local
     group:
-      local: local, common, oauth
-      dev: dev, common, oauth
-      prod: prod, common, oauth
+      local: local, common
+      dev: dev, common
+      prod: prod, common
 


### PR DESCRIPTION
- 각 도메인(naver, kakao, google)에 등록한 어플리케이션 주소값 변경
- Oauth에 설정된 domain 주소가 localhost:8080으로 고정값으로 되어있던 것 수정
- Oauth 로그인 성공 후 Rediret 되는 주소값을 현재 접속한 도메인 주소값으로 맵핑 되도록 처리

#112 