### PR TITLE
Fix: 롤 계정 연동 시 초기 데이터를 전적 정보까지 저장하도록 수정

### DIFF
--- a/src/main/java/com/idle/fmd/domain/lol/repo/LolMatchRepository.java
+++ b/src/main/java/com/idle/fmd/domain/lol/repo/LolMatchRepository.java
@@ -13,4 +13,7 @@ public interface LolMatchRepository extends JpaRepository<LolMatchEntity, Intege
 
     // 특정 유저의 매치 id가 있는지 판별
     boolean existsByLolAccountAccountIdAndMatchId(String accountId, String matchId);
+
+    // 특정 유저의 특정 게임 모드의 데이터의 수 반환
+    long countByLolAccount_IdAndGameMode(Long lolAccountId, String gameMode);
 }

--- a/src/main/java/com/idle/fmd/domain/user/service/UserService.java
+++ b/src/main/java/com/idle/fmd/domain/user/service/UserService.java
@@ -236,7 +236,6 @@ public class UserService {
 
     // 아이디 중복 확인
     public boolean existsByAccountId(String accountId) {
-        log.info(repository.existsByAccountId(accountId).toString());
         return repository.existsByAccountId(accountId);
     }
 
@@ -247,7 +246,6 @@ public class UserService {
 
     // 이메일 중복 확인
     public boolean existsByEmail(String email) {
-        log.info(repository.existsByEmail(email).toString());
         return repository.existsByEmail(email);
     }
 }

--- a/src/main/resources/static/js/mypage.js
+++ b/src/main/resources/static/js/mypage.js
@@ -13,6 +13,7 @@ new Vue({
         profileImage: '',
         password: '',
         passwordCheck: '',
+        linkingLolAccount: false, // 롤 계정 연동 중인지 여부를 나타내는 변수
     },
     // 페이지 방문시 조회 기능
     async created() {
@@ -101,6 +102,9 @@ new Vue({
         },
         // 롤 계정 연동 기능
         async linkLolAccount() {
+            // 롤 계정 연동 시작 시 로딩 상태 활성화
+            this.linkingLolAccount = true;
+
             // 계정 연동 요청
             token = await isValidateToken()
             await axios.post('/lol/save', null, {
@@ -117,6 +121,10 @@ new Vue({
                 .catch(error => {
                     alert('계정 연동이 실패하였습니다.');
                     console.error('계정 연동 실패: ', error);
+                })
+                .finally(() => {
+                    // 롤 계정 연동 종료 시 로딩 상태 비활성화
+                    this.linkingLolAccount = false;
                 })
         },
         async selectImage(event) {

--- a/src/main/resources/templates/mypage.html
+++ b/src/main/resources/templates/mypage.html
@@ -67,10 +67,13 @@
                 <label class="col-sm-4 control-label">롤 닉네임</label>
                 <div class="col-sm-4">
                     <input class="form-control" v-model="lolNickname">
+                    <div class="help-blcok" style="color: gray">계정 연동시 약 1분의 시간이 소요될 수 있습니다.</div>
                 </div>
-                <button class="btn btn-default" type="button" @click="linkLolAccount">롤 계정 연동</button>
+                <button class="btn btn-default" type="button" @click="linkLolAccount" :disabled="linkingLolAccount">
+                    롤 계정 연동
+                    <span v-if="linkingLolAccount" class="glyphicon glyphicon-refresh glyphicon-refresh-animate"></span>
+                </button>
             </div>
-
             <!-- 프로필 이미지 등록 및 변경-->
             <div class="form-group">
                 <label class="col-sm-4 control-label">프로필 이미지</label>


### PR DESCRIPTION
- 롤 계정 연동 요청 시 초기 데이터를 전적 정보까지 저장하도록 수정 -> Job 성능 개선 (30분마다 끌고오는 데이터가 적어짐)
- 마이페이지에서 롤 계정 연동 버튼을 클릭하면 로딩 모양이 뜨도록 디자인 수정, 안내문 추가