### PR TITLE
Fix: 모스트 챔피언이 없을 때 모스트 챔피언 기본이미지 URL 을 전달하도록 수정

### DIFF
--- a/src/main/java/com/idle/fmd/domain/matching/MatchingHandler.java
+++ b/src/main/java/com/idle/fmd/domain/matching/MatchingHandler.java
@@ -192,9 +192,9 @@ public class MatchingHandler extends TextWebSocketHandler {
             attributes.put("rank", "");
             attributes.put("totalWins", 0);
             attributes.put("totalLoses", 0);
-            attributes.put("mostOne", 0);
-            attributes.put("mostTwo", 0);
-            attributes.put("mostThree", 0);
+            attributes.put("mostOne", fileHandler.getChampionImgPath(lolChampDataRepository.findByChampCode(0l).getChampName()));
+            attributes.put("mostTwo", fileHandler.getChampionImgPath(lolChampDataRepository.findByChampCode(0l).getChampName()));
+            attributes.put("mostThree", fileHandler.getChampionImgPath(lolChampDataRepository.findByChampCode(0l).getChampName()));
         }
 
         attributes.put("tierImg", fileHandler.getTierImgPath(session.getAttributes().get("tier").toString()));


### PR DESCRIPTION
● MatchingHandler 에서 모스트 챔피언 정보 전달 부분 수정